### PR TITLE
Update copyright form 2022 to 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,4 +461,4 @@ Contributions are welcome. Please open an issue or submit a pull request.
 
 MIT License
 
-Copyright (c) 2022 Golang Tanzania
+Copyright (c) 2023 Golang Tanzania


### PR DESCRIPTION
Hi Lugano,

I've created a pull request to update the copyright year from 2022 to 2023 in our project. This change ensures that your codebase reflects the current year and maintains our compliance with copyright standards. Please review and merge this update if needed.

Thanks!, Happy code.